### PR TITLE
Add .gitignore to exclude Replit agent state filesAdd .gitignore to exclude Replit agent state directoryAdd .gitignore …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.local/state/replit/agent/


### PR DESCRIPTION
This PR adds a .gitignore file to exclude the `.local/state/replit/agent/` directory.

**Changes:**
- Created .gitignore file in repository root
- Added `.local/state/replit/agent/` to ignored paths

**Purpose:**
- Exclude Replit agent state files from version control
- Prevent unnecessary agent state files from being committed
- Clean up repository by ignoring automatically generated files

**Next steps:**
- After merging, will delete all existing `.agent_state_*.bin` files from the directory
- Verify main application still runs without these files…to exclude agent state filesCreate .gitignore